### PR TITLE
Add product service

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { CartComponent, CheckoutComponent, ProductsComponent, ThankYouComponent } from './components';
+import { ProductService } from './services/product.service';
 
 @NgModule({
   declarations: [
@@ -27,7 +28,9 @@ import { CartComponent, CheckoutComponent, ProductsComponent, ThankYouComponent 
     MatIconModule,
     MatToolbarModule,
   ],
-  providers: [],
+  providers: [
+    ProductService,
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/models/index.ts
+++ b/src/app/models/index.ts
@@ -1,0 +1,1 @@
+export * from './product';

--- a/src/app/models/product.ts
+++ b/src/app/models/product.ts
@@ -1,0 +1,15 @@
+/**
+ * Product models goods for sale in the e-commerce shoppe demo.
+ * A "product" could be an item in the catalog or an item in a shopping cart.
+ * This overlap exists to simplify the demo.
+ */
+export interface Product {
+  description: string;
+  featured?: boolean;    // whether or not this is a promoted product
+  id: number;
+  image: string;
+  price: number;
+  quantity: number;     // quantity could be inventory or number of items in cart
+  title: string;
+  unit: string;        // lb or kg for example
+}

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -1,0 +1,1 @@
+export * from './product.service';

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -58,7 +58,7 @@ export class ProductService {
    * @param result the return value that should be passed to the next operator
    */
   private handleError<T>(operation = 'operation', result?: T) {
-    return (error: any): Observable<T> => {
+    return (error: Error): Observable<T> => {
       console.error(`${operation} failed: ${error.message}`);
 
       // TODO (van) possibly open a snackbar to inform the user of error

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -1,0 +1,89 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+import { environment } from '../../environments/environment';
+import { Product } from '../models'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProductService {
+
+  readonly imageUrl = 'https://fruitshoppe.firebaseapp.com/images'; // URL of product images folder
+  readonly apiRoute = '/products';  // API route to retrieve products
+  readonly apiUrl: string;
+
+  constructor(
+    private sanitizer: DomSanitizer,
+    private http: HttpClient
+  ) {
+    // based on whether to use mocks or the API server, build the full API URL
+    this.apiUrl = environment.useMockApi ? `${environment.localApi}${this.apiRoute}` :
+      `${environment.remoteApi}${this.apiRoute}`;
+  }
+
+  /**
+   * Gets an observable that emits a product from the catalog.
+   * @param id the identifier of the product
+   */
+  getProduct(id: number): Observable<Product | null> {
+    const url = `${this.apiUrl}/${id}`;
+
+    return this.http.get<Product>(url).pipe(
+      map(product => this.setImageUrl(product)),
+      catchError(this.handleError<Product>('getProduct', null))
+    );
+  }
+
+  /**
+   * Gets an observable that emits a list of products from the catalog.
+   * @param query An optional query string to search for products
+   */
+  getProducts(query?: string): Observable<Product[]> {
+    // searching for products will not work for mocks
+    const url = query ? `${this.apiUrl}?q=${query}` : this.apiUrl;
+
+    return this.http.get<Product[]>(url).pipe(
+      map(products => products.map(product => this.setImageUrl(product))),
+      catchError(this.handleError<Product[]>('getProducts', []))
+    );
+  }
+
+  /**
+   * Provides a selector to allow handling of errors from service calls.
+   * @param operation the operation display name that encountered an error
+   * @param result the return value that should be passed to the next operator
+   */
+  private handleError<T>(operation = 'operation', result?: T) {
+    return (error: any): Observable<T> => {
+      console.error(`${operation} failed: ${error.message}`);
+
+      // TODO (van) possibly open a snackbar to inform the user of error
+
+      return of(result as T);
+    };
+  }
+
+  /**
+   * By default, products have the image filename in the `image` property.
+   * This function returns a copy of a product with the `image` property set to
+   * the full URL to the image. It also sanitizes the URL so that it is deemed
+   * safe by Angular.
+   * @param product
+   */
+  private setImageUrl(product: Product): Product {
+    let { image } = product;
+    image = `${this.imageUrl}/${image}`;
+
+    // depending on the usage of the URL, sanitize
+    this.sanitizer.bypassSecurityTrustStyle(image); // if image is used as a style backgroundImage
+
+    return {
+      ...product,
+      image
+    };
+  }
+}

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -13,7 +13,7 @@ import { Product } from '../models'
 export class ProductService {
 
   readonly imageUrl = 'https://fruitshoppe.firebaseapp.com/images'; // URL of product images folder
-  readonly apiRoute = '/products';  // API route to retrieve products
+  readonly productsEndpoint = '/products';  // API route to retrieve products
   readonly apiUrl: string;
 
   constructor(
@@ -21,8 +21,8 @@ export class ProductService {
     private http: HttpClient
   ) {
     // based on whether to use mocks or the API server, build the full API URL
-    this.apiUrl = environment.useMockApi ? `${environment.localApi}${this.apiRoute}` :
-      `${environment.remoteApi}${this.apiRoute}`;
+    this.apiUrl = environment.useMockApi ? `${environment.localApiRoot}${this.productsEndpoint}` :
+      `${environment.remoteApiRoot}${this.productsEndpoint}`;
   }
 
   /**

--- a/src/assets/products
+++ b/src/assets/products
@@ -1,0 +1,150 @@
+[
+  {
+    "id": 1,
+    "title": "Bananas",
+    "description": "The old reliable.",
+    "price": 2.99,
+    "image": "banans.jpg",
+    "unit": "lb.",
+    "quantity": 12
+  },
+  {
+    "id": 2,
+    "title": "Bluebs",
+    "description": "Extra organical and powered by blue.",
+    "price": 6.75,
+    "image": "bluebs.jpg",
+    "unit": "lb.",
+    "featured": true,
+    "quantity": 12
+  },
+  {
+    "id": 3,
+    "title": "Carambola",
+    "description": "An all-star flavor.",
+    "price": 7.24,
+    "image": "carambola.jpg",
+    "unit": "lb.",
+    "quantity": 1
+  },
+  {
+    "id": 4,
+    "title": "Cherries",
+    "description": "Deeply red and passionate.",
+    "price": 6.99,
+    "image": "cherries.jpg",
+    "unit": "lb.",
+    "quantity": 13
+  },
+  {
+    "id": 5,
+    "title": "Cocktail Mix",
+    "description": "Virgin mix for adult use.",
+    "price": 15,
+    "image": "mixeddrink.jpg",
+    "unit": "gallon",
+    "quantity": 5
+  },
+  {
+    "id": 6,
+    "title": "Dragon Fruit",
+    "description": "Kissed by fire, not spicy.",
+    "price": 8.43,
+    "image": "dragonfruit.jpg",
+    "unit": "ea.",
+    "featured": true,
+    "quantity": 18
+  },
+  {
+    "id": 7,
+    "title": "Durian",
+    "description": "Smells worse than it looks.",
+    "price": 14.99,
+    "image": "durian.jpg",
+    "unit": "ea.",
+    "quantity": 4
+  },
+  {
+    "id": 8,
+    "title": "Grapes",
+    "description": "Use either for raisin or wine.",
+    "price": 7.24,
+    "image": "grapes.jpg",
+    "unit": "lb.",
+    "quantity": 19
+  },
+  {
+    "id": 9,
+    "title": "Green Beans",
+    "description": "Beans, beans... great for your heart.",
+    "price": 1.79,
+    "image": "beans.jpg",
+    "unit": "lb.",
+    "quantity": 10
+  },
+  {
+    "id": 10,
+    "title": "Mangocados",
+    "description": "Highly experimental new frewt.",
+    "price": 7.99,
+    "image": "mangocados.jpg",
+    "unit": "ea.",
+    "featured": true,
+    "quantity": 17
+  },
+  {
+    "id": 11,
+    "title": "One Pear",
+    "description": "One lonely pear, eat while sobbing.",
+    "price": 4.99,
+    "image": "pear.jpg",
+    "unit": "",
+    "quantity": 0
+  },
+  {
+    "id": 12,
+    "title": "Oranges de Florida",
+    "description": "Lose the sleeves, you're in Florida.",
+    "price": 4.99,
+    "image": "oranges.jpg",
+    "unit": "lb.",
+    "quantity": 3
+  },
+  {
+    "id": 13,
+    "title": "Peacharines",
+    "description": "This one's on us, Mother Nature.",
+    "price": 6.39,
+    "image": "peacherines.jpg",
+    "unit": "lb.",
+    "quantity": 18
+  },
+  {
+    "id": 14,
+    "title": "Peaches",
+    "description": "The pride and joy of Georgia.",
+    "price": 4.29,
+    "image": "peaches.jpg",
+    "unit": "lb.",
+    "featured": true,
+    "quantity": 2
+  },
+  {
+    "id": 15,
+    "title": "Pears",
+    "description": "More than one pear, pears.",
+    "price": 9.22,
+    "image": "pears.jpg",
+    "unit": "lb.",
+    "quantity": 7
+  },
+  {
+    "id": 16,
+    "title": "Raspberries",
+    "description": "Next stop, Yumsville.",
+    "price": 5.99,
+    "image": "rasps.jpg",
+    "unit": "lb.",
+    "quantity": 11
+  }
+]

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,11 +2,18 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
+/**
+ * Define configuration options used by the app:
+ * production - whether or not this app is running in production
+ * localApi - mock files that contain data (i.e. emulate an API resource locally)
+ * remoteApi - the API base URL if hosting the backend demo (https://github.com/fullstorydev/api-shoppe-demo)
+ * useMockApi - true to use localApi, false to use the remoteApi
+ */
 export const environment = {
   production: false,
   localApi: '/assets',
   remoteApi: 'http://localhost:3000/api',
-  useMockApi: true, // set to false and run https://github.com/fullstorydev/api-shoppe-demo
+  useMockApi: true,
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,10 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  localApi: '/assets',
+  remoteApi: 'http://localhost:3000/api',
+  useMockApi: true, // set to false and run https://github.com/fullstorydev/api-shoppe-demo
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,14 +5,14 @@
 /**
  * Define configuration options used by the app:
  * production - whether or not this app is running in production
- * localApi - mock files that contain data (i.e. emulate an API resource locally)
- * remoteApi - the API base URL if hosting the backend demo (https://github.com/fullstorydev/api-shoppe-demo)
+ * localApiRoot - mock files that contain data (i.e. emulate an API resource locally)
+ * remoteApiRoot - the API base URL if hosting the backend demo (https://github.com/fullstorydev/api-shoppe-demo)
  * useMockApi - true to use localApi, false to use the remoteApi
  */
 export const environment = {
   production: false,
-  localApi: '/assets',
-  remoteApi: 'http://localhost:3000/api',
+  localApiRoot: '/assets',
+  remoteApiRoot: 'http://localhost:3000/api',
   useMockApi: true,
 };
 


### PR DESCRIPTION
This PR adds a Product service.  Specifically:
- It adds (copies) the Product model from the backend api-shoppe-demo
- Provides an `environment` object to configure the app; this is useful for developers that may not want to run the actual api-shoppe-demo but still want to explore the app. To that end, there's a toggle between using local mocks and the api-shoppe-demo.
- Provides a local mock of products in JSON format in `assets`. The file is named `products` without the json extension because that allows the API route `/products` to be re-used between local and remote service calls.
- An Angular service ProductService provides the bulk of communication and abstraction to the backend