### PR TITLE
add products page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,8 +1,11 @@
+import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatGridListModule } from '@angular/material/grid-list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatToolbarModule } from '@angular/material/toolbar';
 
@@ -24,7 +27,10 @@ import { ProductService } from './services/product.service';
     AppRoutingModule,
     BrowserAnimationsModule,
     FlexLayoutModule,
+    HttpClientModule,
     MatButtonModule,
+    MatCardModule,
+    MatGridListModule,
     MatIconModule,
     MatToolbarModule,
   ],

--- a/src/app/components/products/products.component.html
+++ b/src/app/components/products/products.component.html
@@ -1,1 +1,17 @@
-<p>products works!</p>
+<mat-grid-list class="product-list" cols="{{numColumns}}" [gutterSize]="'1px'">
+  <mat-grid-tile *ngFor=" let product of products">
+    <mat-card class="product-card">
+      <div class="product-image" [style.backgroundImage]="'url(' + product.image +')'"></div>
+      <mat-card-header class="product-header">
+        <mat-card-title>{{product.title}}</mat-card-title>
+        <mat-card-subtitle><b>${{product.price}}</b><small> / </small>{{product.unit}}</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <p>{{product.description}}</p>
+      </mat-card-content>
+      <mat-card-actions fxLayout="row" fxLayoutAlign="end center">
+        <button mat-stroked-button color="primary">Add to Cart</button>
+      </mat-card-actions>
+    </mat-card>
+  </mat-grid-tile>
+</mat-grid-list>

--- a/src/app/components/products/products.component.scss
+++ b/src/app/components/products/products.component.scss
@@ -1,0 +1,28 @@
+.mat-card {
+  padding-top: 0px;
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
+.mat-card-actions,
+.mat-card-content {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.product-header {
+  margin: 0px;
+}
+
+.product-list {
+  margin: 16px;
+}
+
+.product-image {
+  height: 120px;
+  width: 300px;
+  background-repeat: no-repeat;
+  background-position: 50%;
+  background-size: cover;
+  margin-bottom: 12px;
+}

--- a/src/app/components/products/products.component.ts
+++ b/src/app/components/products/products.component.ts
@@ -1,15 +1,60 @@
 import { Component, OnInit } from '@angular/core';
+import { MediaChange, MediaObserver } from '@angular/flex-layout';
+import { ProductService } from 'src/app/services';
+import { Product } from 'src/app/models';
+
+/**
+ * Breakpoint aliases (e.g. 'sm') to number of grid-list columns.
+ */
+interface BreakpointMap {
+  [name: string]: number
+}
 
 @Component({
   selector: 'app-products',
   templateUrl: './products.component.html',
-  styles: []
+  styleUrls: ['./products.component.scss']
 })
 export class ProductsComponent implements OnInit {
 
-  constructor() { }
+  // TODO (van) a better approach is min/max width based on the product's image size
+  private columnBreakpoints: BreakpointMap = {
+    'default': 3,
+    'xs': 1,
+    'sm': 2,
+    'md': 3,
+    'lg': 4,
+    'xl': 5,
+  };
+
+  numColumns = this.columnBreakpoints['default'];
+  products: Product[] = [];
+
+  constructor(
+    private mediaObserver: MediaObserver,
+    private productService: ProductService,
+  ) { }
 
   ngOnInit() {
+    this.observeBreakpoints();
+    this.buildProductList();
   }
 
+  /**
+   * Observes for breakpoint changes and updates the number of columns.
+   * See `columnBreakpoints` for breakpoint-to-columns mapping.
+   */
+  private observeBreakpoints(): void {
+    this.mediaObserver.media$.subscribe((change: MediaChange) => {
+      const n = this.columnBreakpoints[change.mqAlias];
+      this.numColumns = n > 0 ? n : this.columnBreakpoints['default'];
+    });
+  }
+
+  /**
+   * Builds a list of products from the catalog.
+   */
+  buildProductList(): void {
+    this.productService.getProducts().subscribe(products => this.products = products);
+  }
 }


### PR DESCRIPTION
This PR builds on the basic ProductsComponent:
- adds Angular UI modules to show a product as a card
- arranges the cards using gridlist and flex-layout
- populates the cards using the ProductService and RxJS observable (standard Angular convention)