### PR TITLE
Add CartService

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,8 +1,6 @@
 <mat-toolbar>
-  <a routerLink="/" class="toolbar-title">{{ title | uppercase }}</a>
+  <a routerLink="/products" class="toolbar-title">{{ title | uppercase }}</a>
   <span class="toolbar-spacer"></span>
-  <a mat-flat-button color="primary" routerLink="cart" aria-label="Shopping Cart">
-    <mat-icon class="toolbar-icon">shopping_cart</mat-icon>My Cart
-  </a>
+  <app-cart-button></app-cart-button>
 </mat-toolbar>
 <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,7 +12,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { CartComponent, CheckoutComponent, ProductsComponent, ThankYouComponent } from './components';
-import { ProductService } from './services/product.service';
+import { CartService, ProductService } from './services';
 
 @NgModule({
   declarations: [
@@ -35,6 +35,7 @@ import { ProductService } from './services/product.service';
     MatToolbarModule,
   ],
   providers: [
+    CartService,
     ProductService,
   ],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,13 +11,14 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { CartComponent, CheckoutComponent, ProductsComponent, ThankYouComponent } from './components';
+import { CartComponent, CartButtonComponent, CheckoutComponent, ProductsComponent, ThankYouComponent } from './components';
 import { CartService, ProductService } from './services';
 
 @NgModule({
   declarations: [
     AppComponent,
     CartComponent,
+    CartButtonComponent,
     CheckoutComponent,
     ProductsComponent,
     ThankYouComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatBadgeModule } from '@angular/material/badge';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatGridListModule } from '@angular/material/grid-list';
@@ -29,6 +30,7 @@ import { CartService, ProductService } from './services';
     BrowserAnimationsModule,
     FlexLayoutModule,
     HttpClientModule,
+    MatBadgeModule,
     MatButtonModule,
     MatCardModule,
     MatGridListModule,

--- a/src/app/components/cart/cart-button.component.html
+++ b/src/app/components/cart/cart-button.component.html
@@ -1,0 +1,4 @@
+<a routerLink="/cart" mat-flat-button color="primary" routerLink="cart" aria-label="Shopping Cart"
+  matBadge="{{cartBadge}}" matBadgePosition="above after" matBadgeColor="accent">
+  <mat-icon class="toolbar-icon">shopping_cart</mat-icon>My Cart
+</a>

--- a/src/app/components/cart/cart-button.component.ts
+++ b/src/app/components/cart/cart-button.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+import { CartService } from '../../services';
+
+@Component({
+  selector: 'app-cart-button',
+  templateUrl: 'cart-button.component.html',
+})
+export class CartButtonComponent implements OnInit {
+  cartBadge: number;
+
+  constructor(private cartService: CartService) {
+
+  }
+
+  ngOnInit(): void {
+    this.cartService.getItems().subscribe(items => this.cartBadge = items.length);
+  }
+}

--- a/src/app/components/index.ts
+++ b/src/app/components/index.ts
@@ -1,4 +1,5 @@
 export * from './cart/cart.component';
+export * from './cart/cart-button.component';
 export * from './checkout/checkout.component';
 export * from './products/products.component';
 export * from './thank-you/thank-you.component';

--- a/src/app/components/products/products.component.html
+++ b/src/app/components/products/products.component.html
@@ -10,7 +10,7 @@
         <p>{{product.description}}</p>
       </mat-card-content>
       <mat-card-actions fxLayout="row" fxLayoutAlign="end center">
-        <button mat-stroked-button color="primary">Add to Cart</button>
+        <button mat-stroked-button color="primary" (click)="addToCart(product)">Add to Cart</button>
       </mat-card-actions>
     </mat-card>
   </mat-grid-tile>

--- a/src/app/components/products/products.component.ts
+++ b/src/app/components/products/products.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MediaChange, MediaObserver } from '@angular/flex-layout';
-import { ProductService } from 'src/app/services';
+import { ProductService, CartService } from 'src/app/services';
 import { Product } from 'src/app/models';
 
 /**
@@ -31,6 +31,7 @@ export class ProductsComponent implements OnInit {
   products: Product[] = [];
 
   constructor(
+    private cartService: CartService,
     private mediaObserver: MediaObserver,
     private productService: ProductService,
   ) { }
@@ -38,6 +39,15 @@ export class ProductsComponent implements OnInit {
   ngOnInit() {
     this.observeBreakpoints();
     this.buildProductList();
+  }
+
+  /**
+   * Adds a product to the user's shopping cat.
+   * @param product the Product to be added
+   */
+  addToCart(product: Product) {
+    const { id } = product;
+    this.cartService.addItem(id);
   }
 
   /**

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import { Product } from '../models';
+import { ReplaySubject } from 'rxjs';
+import { ProductService } from './product.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CartService {
+
+  private items: Product[] = [];
+  private subject = new ReplaySubject<Product[]>();
+
+  constructor(private productService: ProductService) {
+
+  }
+
+  /**
+   * Adds an item to the shopping cart. If not already added, product details
+   * will be obtained from the catalog. If the item already exists, the item's
+   * quantity will be incremented by one.
+   * @param productId the Product ID of the corresponding item
+   */
+  addItem(productId: number): void {
+    // check if the item is already in the cart
+    const item = this.items.find(product => product.id === productId);
+
+    if (item) {
+      // update the item's quantity and notify observers
+      const { quantity } = item;
+      item.quantity += quantity;
+
+      this.subject.next(this.items);
+    } else {
+      // get the product from the catalog and add as an initial item
+      this.productService.getProduct(productId).subscribe(product => {
+        const quantity = 1; // initial quantity of 1
+
+        const item: Product = {
+          ...product,
+          quantity
+        }
+
+        // store the item and notify observers
+        this.items.push(item);
+        this.subject.next(this.items);
+      });
+    }
+  }
+
+  /**
+   * Gets the items in the cart as an Observable.
+   * A ReplaySubject is used to re-emit the cart's items to newly instantiated
+   * components.
+   */
+  getItems(): ReplaySubject<Product[]> {
+    return this.subject;
+  }
+
+  /**
+   * Removes an item entirely from the cart.
+   * @param productId the Product ID of the corresponding item
+   */
+  removeItem(productId: number): void {
+    // find the item
+    const index = this.items.findIndex(product => product.id === productId)
+
+    if (index) {
+      // remove tthe item and notify observers
+      this.items = this.items.splice(index, 1);
+      this.subject.next(this.items);
+    }
+  }
+}

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -65,9 +65,9 @@ export class CartService {
     // find the item
     const index = this.items.findIndex(product => product.id === productId)
 
-    if (index) {
+    if (index >= 0) {
       // remove tthe item and notify observers
-      this.items = this.items.splice(index, 1);
+      this.items.splice(index, 1);
       this.subject.next(this.items);
     }
   }

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -34,11 +34,9 @@ export class CartService {
     } else {
       // get the product from the catalog and add as an initial item
       this.productService.getProduct(productId).subscribe(product => {
-        const quantity = 1; // initial quantity of 1
-
         const item: Product = {
           ...product,
-          quantity
+          quantity: 1 // initial quantity of 1
         }
 
         // store the item and notify observers

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -1,1 +1,2 @@
+export * from './cart.service';
 export * from './product.service';

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -13,7 +13,7 @@ export const environment = {
   production: false,
   localApiRoot: '/assets',
   remoteApiRoot: 'http://localhost:3000/api',
-  useMockApi: true,
+  useMockApi: false,
 };
 
 /*


### PR DESCRIPTION
This PR adds a CartService to handle shopping cart operations:
- CartService handles all cart implementation details
- The cart requires an API to get a product by ID, so the useMockApi flag is now `false`
- Add to Cart button now communicates with the service
- The button that displays the cart now has a badge that shows number of items in the cart