### PR TITLE
Update readme to run app from NPM scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install and start the web app with the following commands.
 ```bash
 cd angular-shoppe-demo
 npm install
-ng serve
+npm run start
 ```
 
 You should see a *Compiled successfully* message.  Then open [http://localhost:4200](http://localhost:4200) in your browser.


### PR DESCRIPTION
`ng serve` won't work for folks who don't have `ng` globally installed. This PR uses the NPM script that executes this command (and runs the locally installed `ng`)