### PR TITLE
Add data layers

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { AngularFireModule } from '@angular/fire';
+import { AngularFireAnalyticsModule, ScreenTrackingService } from '@angular/fire/analytics';
 import { AngularFireAuthModule } from '@angular/fire/auth';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -41,6 +42,7 @@ import { LoginComponent } from './components/login/login.component';
   imports: [
     BrowserModule,
     AngularFireModule.initializeApp(environment.firebase),
+    AngularFireAnalyticsModule,
     AngularFireAuthModule,
     AppRoutingModule,
     BrowserAnimationsModule,
@@ -64,6 +66,7 @@ import { LoginComponent } from './components/login/login.component';
   providers: [
     CartService,
     ProductService,
+    ScreenTrackingService,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/components/checkout/checkout.component.ts
+++ b/src/app/components/checkout/checkout.component.ts
@@ -1,8 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+
 import { Observable } from 'rxjs';
+import { first } from 'rxjs/operators'
 import { Product, State, states } from 'src/app/models';
 import { CartService } from 'src/app/services';
+import { DatalayerService } from 'src/app/services/datalayer.service';
 
 @Component({
   selector: 'app-checkout',
@@ -16,6 +19,7 @@ export class CheckoutComponent implements OnInit {
 
   constructor(
     private cartService: CartService,
+    private datalayer: DatalayerService,
     private router: Router,
   ) {
 
@@ -37,6 +41,7 @@ export class CheckoutComponent implements OnInit {
    */
   checkout() {
     // do some processing ...
+    this.items$.pipe(first()).subscribe(items => this.datalayer.checkout(items));
     this.cartService.clear();
     this.router.navigate(['/thankyou']);
   }

--- a/src/app/models/ceddl.ts
+++ b/src/app/models/ceddl.ts
@@ -1,0 +1,92 @@
+/**
+ * Mocks a CEDDL compliant data layer.
+ * See https://www.w3.org/2013/12/ceddl-201312.pdf
+ *
+ * Note that this is a subset for the purposes of demonstration.
+ */
+
+export const ceddlVersion = '1.0';
+
+/**
+ * The root JavaScript Object (JSO) MUST be window.digitalData.
+ * All data properties within this specification MUST fall within the hierarchy of the digitalData
+ * object.
+ */
+export interface CEDDL {
+  pageInstanceID: string;
+  product: Product[];
+  cart: Cart;
+  version: string;
+}
+
+/**
+ * The Product object carries details about a particular product with frequently used properties
+ * listed below. This is intended for data about products displayed on pages or other content. For
+ * products added to a shopping cart or ordered in a transaction, see the Cart and Transaction
+ * objects below.
+ */
+export interface Product {
+  productInfo: ProductInfo;
+  category: ProductCategory;
+  linkedProduct: LinkedProduct[];
+  attributes?: { [key: string]: any };
+}
+
+export interface ProductInfo {
+  productID: string;
+  productName: string;
+  description: string;
+  productURL: string;
+  productImage: string;
+  productThumbnail: string;
+  manufacturer: string;
+  sku: string;
+  color: string;
+  size: string;
+}
+
+export interface ProductCategory {
+  primaryCategory: string;
+  subCategory1?: string;
+  productType?: string;
+}
+
+export interface LinkedProduct {
+  productInfo: ProductInfo
+}
+
+/**
+ * The Cart object carries details about a shopping cart or basket and the products that have been
+ * added to it. The Cart object is intended for a purchase that has not yet been completed. See the
+ * Transaction object below for completed orders.
+ */
+export interface Cart {
+  cartID: string;
+  price: TotalCartPrice;
+  attributes: { [key: string]: any };
+  item: ProductItem[];
+}
+
+export interface Price {
+  basePrice: number;
+  voucherCode: string;
+  voucherDiscount: number;
+  currency: string; // ISO 4217 is RECOMMENDED
+  taxRate: number;
+  shipping: number;
+  shippingMethod: string;
+  priceWithTax: number;
+}
+
+export interface TotalCartPrice extends Price {
+  cartTotal: number;
+}
+
+export interface ProductItem {
+  productInfo: ProductInfo;
+  category: ProductCategory;
+  quantity: number;
+  price: Price;
+  linkedProduct: LinkedProduct[];
+  attributes: { [key: string]: any };
+}

--- a/src/app/services/datalayer.service.ts
+++ b/src/app/services/datalayer.service.ts
@@ -1,0 +1,185 @@
+import { Injectable } from '@angular/core';
+import { AngularFireAnalytics } from '@angular/fire/analytics';
+import * as firebase from 'firebase';
+
+import { Cart, Price, ProductInfo, ProductItem, TotalCartPrice } from '../models/ceddl';
+import { Product } from '../models';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DatalayerService {
+
+  constructor(private analytics: AngularFireAnalytics) { }
+
+  /**
+   * Updates data layers with product information added to the cart.
+   * @param product added
+   * @param items in the cart after addition
+   */
+  addToCart(product: Product, items: Product[]) {
+    // Google
+    this.analytics.logEvent(firebase.analytics.EventName.ADD_TO_CART, product);
+
+    // Tealium
+    Object.assign(((window as any).utag.data), this.tealiumCart(product, items, 'cart_add'));
+
+    // CEDDL
+    const digitalData = window['digitalData'] as any;
+    (digitalData.cart as Cart).item = items.map(item => this.ceddlProductItem(item));
+    (digitalData.cart as Cart).price = this.ceddlTotalCartPrice((digitalData.cart as Cart).item);
+  }
+
+  /**
+   * Updates data layers with product information removed from the cart.
+   * @param product removed
+   * @param items in the cart after removal
+   */
+  removeFromCart(product: Product, items: Product[]) {
+    // Google
+    this.analytics.logEvent(firebase.analytics.EventName.REMOVE_FROM_CART, product);
+
+    // Tealium
+    Object.assign(((window as any).utag.data), this.tealiumCart(product, items, 'cart_remove'));
+
+    // CEDDL
+    const digitalData = window['digitalData'] as any;
+    (digitalData.cart as Cart).item = items.map(item => this.ceddlProductItem(item));
+    (digitalData.cart as Cart).price = this.ceddlTotalCartPrice((digitalData.cart as Cart).item);
+  }
+
+  /**
+   * Updates data layers with checkout information.
+   * @param items used during checkout
+   */
+  checkout(items: Product[]) {
+    // Google
+    this.analytics.logEvent(firebase.analytics.EventName.PURCHASE, { items });
+
+    // Tealium
+    Object.assign(((window as any).utag.data), this.tealiumCheckout(items));
+  }
+
+  /**
+   * Builds a Tealium cart object for the data layer.
+   * @param product added or removed from the cart
+   * @param items currently in the cart (after addition or removal)
+   * @param tealiumEvent name from the retail definition (i.e. cart_add or cart_remove)
+   */
+  private tealiumCart(product: Product, items: Product[], tealiumEvent: 'cart_add' | 'cart_remove'): any {
+    // NOTE toString() for numeric values is recommended in Tealium documentation
+    return {
+      cart_product_id: items.map((item: Product) => item.id.toString()),
+      cart_product_price: items.map((item: Product) => item.price.toString()),
+      cart_product_quantity: items.map((item: Product) => item.quantity.toString()),
+      product_id: [product.id],
+      product_image_url: [product.image],
+      product_name: [product.title],
+      product_original_price: [product.price],
+      product_price: [product.price],
+      product_quantity: [product.quantity.toString()],
+      tealium_event: tealiumEvent
+    };
+  }
+
+  /**
+   * Builds a Tealium checkout object for the data layer.
+   * @param items currently in the cart
+   */
+  private tealiumCheckout(items: Product[]): any {
+    return {
+      cart_total_items: items.length.toString(),
+      cart_total_value: items.reduce((tax: number, item: Product) => tax += (item.price * item.quantity) * 1.09, 0),
+      order_currency_code: 'USD',
+      order_discount_amount: '0.00',
+      order_id: Date.now().toString(),
+      order_payment_type: 'visa',
+      order_promo_code: '',
+      order_shipping_amount: `${items.length}.00`,
+      order_shipping_type: 'UPS',
+      order_subtotal: items.reduce((tax: number, item: Product) => tax += item.price * item.quantity, 0),
+      order_tax_amount: items.reduce((tax: number, item: Product) => tax += (item.price * item.quantity) * 1.09, 0),
+      order_total: items.reduce((tax: number, item: Product) => tax += (item.price * item.quantity) * 1.09, 0),
+      page_name: 'Order Confirmation - Thank You',
+      page_type: 'order',
+      product_id: items.map(item => item.id.toString()),
+      product_image_url: items.map(item => item.image),
+      product_name: items.map(item => item.title),
+      product_original_price: items.map(item => item.price.toString()),
+      product_price: items.map(item => item.price.toString()),
+      product_quantity: items.map(item => item.quantity.toString()),
+      tealium_event: 'purchase'
+    };
+  }
+
+  /**
+   * CEDDL Price converter.
+   * @param item to convert
+   */
+  ceddlPrice(item: Product): Price {
+    return {
+      basePrice: item.price,
+      currency: 'USD',
+      taxRate: 0.09,
+      shipping: 1.00,
+      shippingMethod: 'UPS-Ground',
+      priceWithTax: item.price * 1.09,
+      voucherCode: '',
+      voucherDiscount: 0.00,
+    };
+  }
+
+  /**
+   * CEDDL ProductInfo converter.
+   * @param product to convert
+   */
+  ceddlProductInfo(product: Product): ProductInfo {
+    return {
+      productID: product.id.toString(),
+      productName: product.title,
+      description: product.description,
+      productImage: product.image,
+      productURL: location.host,
+      productThumbnail: product.image,
+      manufacturer: 'FruitShoppe',
+      sku: product.id.toString(),
+      color: 'N/A',
+      size: 'N/A',
+    };
+  }
+
+  /**
+   * CEDDL ProductItem converter.
+   * @param item to convert
+   */
+  ceddlProductItem(item: Product): ProductItem {
+    return {
+      productInfo: this.ceddlProductInfo(item),
+      category: {
+        primaryCategory: 'fruit',
+      },
+      quantity: item.quantity,
+      price: this.ceddlPrice(item),
+      linkedProduct: [],
+      attributes: {},
+    };
+  }
+
+  /**
+   * CEDDL TotalCartPrice converter.
+   * @param items to build TotalCartPrice
+   */
+  ceddlTotalCartPrice(items: ProductItem[]): TotalCartPrice {
+    return {
+      basePrice: items.reduce((price: number, item: ProductItem) => price += item.price.basePrice * item.quantity, 0),
+      voucherCode: '',
+      voucherDiscount: 0.00,
+      currency: 'USD',
+      taxRate: 0.09,
+      shipping: items.reduce((price: number, item: ProductItem) => price += item.price.shipping, 0),
+      shippingMethod: 'UPS-Ground',
+      priceWithTax: items.reduce((price: number, item: ProductItem) => price += item.price.priceWithTax * item.quantity, 0),
+      cartTotal: items.reduce((price: number, item: ProductItem) => price += (item.price.priceWithTax * item.quantity) + item.price.shipping, 0)
+    };
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,12 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <!-- data layers -->
+  <script>
+    dataLayer = []; // Google
+    utag = { data: { tealium_event: "page_view" } }; // Tealium
+    digitalData = { cart: { cartID: Date.now(), item: [], price: { cartTotal: 0.00 }, attributes: {} } }; // CEDDL
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION
This PR adds a few data layers: Google (via firebase), Tealium, and CEDDL (the latter two are baked into the demo).  For now, the following use cases/data layers are supported:

add to cart - Google, Tealium, CEDDL
remove from cart - Google, Tealium, CEDDL
checkout - Google, Tealium

Until Data Layer Observer is GA, I'm going to hold off adding anything to the readme.